### PR TITLE
Add Larmor precession example

### DIFF
--- a/examples/classical_solenoid.py
+++ b/examples/classical_solenoid.py
@@ -9,7 +9,6 @@ from spinecho_sim import (
 )
 from spinecho_sim.solenoid import (
     plot_expectation_angles,
-    plot_expectation_trajectory_3d,
     plot_expectation_values,
     plot_spin_states,
 )
@@ -68,17 +67,6 @@ if __name__ == "__main__":
     )
     output_path = (
         f"./examples/classical_solenoid.expectation.{num_spins}-spins_S-{S_label}.pdf"
-    )
-    plt.savefig(output_path, dpi=600, bbox_inches="tight")
-
-    fig, ax = plot_expectation_trajectory_3d(result)
-    fig.suptitle(
-        r"Classical Larmor Precession of ${}^3$He in a Sinusoidal Magnetic Field, "
-        r"$\mathbf{{B}} \approx B_0 \mathbf{z}$, "
-        f"{num_spins} spins, $S={S_label}$",
-    )
-    output_path = (
-        f"./examples/classical_solenoid.trajectory.{num_spins}-spins_S-{S_label}.pdf"
     )
     plt.savefig(output_path, dpi=600, bbox_inches="tight")
 

--- a/examples/larmor_precession.py
+++ b/examples/larmor_precession.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from spinecho_sim import (
+    ParticleState,
+    Solenoid,
+)
+from spinecho_sim.solenoid import (
+    plot_expectation_trajectory,
+)
+from spinecho_sim.state import (
+    CoherentSpin,
+    ParticleDisplacement,
+)
+
+if __name__ == "__main__":
+    # When a particle is placed in a solenoid, it will precess around the magnetic field axis.
+    # if it is displaced from the center of the solenoid, it will also slightly
+    # rotate towards s_z, which reduces the intensity of the beam.
+    particle_velocity = 714
+    initial_state = ParticleState(
+        spin=CoherentSpin(theta=np.pi / 2, phi=0).as_generic(n_stars=1),
+        parallel_velocity=714,
+        displacement=ParticleDisplacement(r=1.16e-3),
+    )
+
+    solenoid = Solenoid.from_experimental_parameters(
+        length=0.75,
+        magnetic_constant=3.96e-3,
+        current=0.1,
+    )
+    result = solenoid.simulate_trajectory(initial_state, n_steps=1000)
+
+    n_stars = result.spins.n_stars
+    S = n_stars / 2
+    S_label = f"{S:.0f}" if S is int else f"{S:.1f}"
+
+    fig, ax, _ = plot_expectation_trajectory(result.trajectory)
+    fig.suptitle(
+        r"Classical Larmor Precession of ${}^3$He in a Sinusoidal Magnetic Field, "
+        r"$\mathbf{{B}} \approx B_0 \mathbf{z}$, "
+        f"$S={S_label}$",
+    )
+    output_path = f"./examples/larmor_precession.trajectory.{n_stars}.pdf"
+    plt.savefig(output_path, dpi=600, bbox_inches="tight")
+
+    plt.show()

--- a/spinecho_sim/solenoid/__init__.py
+++ b/spinecho_sim/solenoid/__init__.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from spinecho_sim.solenoid._plot import (
     plot_expectation_angles,
-    plot_expectation_trajectory_3d,
+    plot_expectation_trajectories,
+    plot_expectation_trajectory,
     plot_expectation_values,
     plot_spin_states,
 )
@@ -19,7 +20,8 @@ __all__ = [
     "SolenoidSimulationResult",
     "SolenoidTrajectory",
     "plot_expectation_angles",
-    "plot_expectation_trajectory_3d",
+    "plot_expectation_trajectories",
+    "plot_expectation_trajectory",
     "plot_expectation_values",
     "plot_spin_states",
 ]

--- a/spinecho_sim/solenoid/_plot.py
+++ b/spinecho_sim/solenoid/_plot.py
@@ -6,7 +6,7 @@ import numpy as np
 from matplotlib import pyplot as plt
 
 from spinecho_sim.state import get_expectation_values
-from spinecho_sim.util import Measure, get_figure, plot_measure, plot_measure_label
+from spinecho_sim.util import Measure, get_figure, get_measure_label, measure_data
 
 if TYPE_CHECKING:
     from matplotlib.axes import Axes
@@ -31,7 +31,7 @@ def plot_spin_state(
 
     positions = result.positions
     states = result.spins.momentum_states[idx, :, :]
-    state_measure = plot_measure(states, measure)
+    state_measure = measure_data(states, measure)
 
     average_state_measure = np.average(state_measure, axis=0)
 
@@ -67,7 +67,7 @@ def plot_spin_state(
         label=r"Mean $\pm 1\sigma$",
     )
 
-    ax.set_ylabel(f"{ms_labels[idx]} {plot_measure_label(measure)}")
+    ax.set_ylabel(f"{ms_labels[idx]} {get_measure_label(measure)}")
     ax.legend(loc="lower right")
     ax.set_xlim(positions[0], positions[-1])
 

--- a/spinecho_sim/state/_displacement.py
+++ b/spinecho_sim/state/_displacement.py
@@ -17,8 +17,8 @@ class ParticleDisplacement:
     - theta is the angle from the positive x-axis in the x-y plane.
     """
 
-    r: float
-    theta: float
+    r: float = 0
+    theta: float = 0
 
     @property
     def x(self) -> float:

--- a/spinecho_sim/state/_state.py
+++ b/spinecho_sim/state/_state.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
+from spinecho_sim.state._displacement import ParticleDisplacement
+
 if TYPE_CHECKING:
-    from spinecho_sim.state._displacement import ParticleDisplacement
     from spinecho_sim.state._spin import GenericSpin
 
 
@@ -13,7 +14,7 @@ class ParticleState:
     """Represents the state of a particle in the simulation."""
 
     spin: GenericSpin
-    displacement: ParticleDisplacement
+    displacement: ParticleDisplacement = field(default_factory=ParticleDisplacement)
     parallel_velocity: float
     gyromagnetic_ratio: float = -2.04e8  # default value for 3He
 

--- a/spinecho_sim/util.py
+++ b/spinecho_sim/util.py
@@ -24,7 +24,7 @@ def get_figure(ax: Axes | None = None) -> tuple[Figure | SubFigure, Axes]:
 Measure = Literal["real", "imag", "abs", "arg"]
 
 
-def plot_measure(arr: np.ndarray, measure: Measure) -> np.ndarray:
+def measure_data(arr: np.ndarray, measure: Measure) -> np.ndarray:
     """Get the specified measure of an array."""
     if measure == "real":
         return np.real(arr)
@@ -37,7 +37,7 @@ def plot_measure(arr: np.ndarray, measure: Measure) -> np.ndarray:
     return None
 
 
-def plot_measure_label(measure: Measure) -> str:
+def get_measure_label(measure: Measure) -> str:
     """Get the specified measure of an array."""
     if measure == "real":
         return "Real part"

--- a/tests/solenoid_test.py
+++ b/tests/solenoid_test.py
@@ -165,13 +165,13 @@ def test_simulate_trajectory_high_spin() -> None:
 
     # Both theta and phi should be the same for all stars
     np.testing.assert_allclose(
-        result.spins.theta[..., 0],
-        result.spins.theta[..., 1],
+        result.spins.theta[0, ..., 0],
+        result.spins.theta[1, ..., 1],
         atol=1e-4,
     )
     np.testing.assert_allclose(
-        result.spins.phi[..., 0],
-        result.spins.phi[..., 1],
+        result.spins.phi[0, ..., 0],
+        result.spins.phi[1, ..., 1],
         atol=1e-4,
     )
 

--- a/tests/state_test.py
+++ b/tests/state_test.py
@@ -125,7 +125,6 @@ def test_expectation_large_state(n_stars: int) -> None:
 
 
 def test_spin_from_iter() -> None:
-    # Test that Spin.from_iter can handle a list of Spin objects
     spins = [
         CoherentSpin(theta=np.pi / 2, phi=0).as_generic(n_stars=2),
         CoherentSpin(theta=np.pi / 3, phi=np.pi / 4).as_generic(n_stars=2),
@@ -151,10 +150,10 @@ def test_spin_from_iter() -> None:
 
 
 def test_trajectory_list() -> None:
-    # Test that Spin.from_iter can handle a list of Spin objects
+    n_stars = 2
     spins = [
-        CoherentSpin(theta=np.pi / 2, phi=0).as_generic(n_stars=2),
-        CoherentSpin(theta=np.pi / 3, phi=np.pi / 4).as_generic(n_stars=2),
+        CoherentSpin(theta=np.pi / 2, phi=0).as_generic(n_stars=n_stars),
+        CoherentSpin(theta=np.pi / 3, phi=np.pi / 4).as_generic(n_stars=n_stars),
     ]
     trajectory = Trajectory(
         spins=Spin.from_iter(spins),
@@ -162,8 +161,10 @@ def test_trajectory_list() -> None:
         parallel_velocity=10.0,
     )
     trajectory_list = TrajectoryList.from_trajectories([trajectory])
+
     assert len(trajectory_list) == 1
-    assert trajectory_list.spins.n_stars == 2
+    assert trajectory_list.spins.n_stars == n_stars
+
     np.testing.assert_array_equal(
         trajectory_list.spins.theta[0, ..., 0],
         trajectory.spins.theta[..., 0],


### PR DESCRIPTION
breaks up example into S-x/y/z and state occupation examples 

Also removed hardcoded colours from plots. if a user wants to modify the colours used by plots they can modify the colour cycle directly using something like

```
plt.rc('axes', prop_cycle=plt.cycler(color=['r', 'g', 'b', 'y']))
```